### PR TITLE
Lower dependencies versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ end
 ## <a name="plugins"></a> Plugins
 RabbitmqClient plugins are classes that define a callbacks that can be executed before or after events that occuers during RabbitmqClient lifecycle.
 Current supprted lifecycle events are:
-  - publish: occure when publisgin a massage is triggered.
+  - publish: occure when publishing a massage is triggered.
 
 Here is an example where we define a plugin to add some headers to message options before publishing the message.
 

--- a/rabbitmq_client.gemspec
+++ b/rabbitmq_client.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage
 
-  spec.add_runtime_dependency 'activesupport', '~> 6.0.0'
-  spec.add_runtime_dependency 'bunny', '~> 2.14.3'
+  spec.add_runtime_dependency 'activesupport', '> 5.0.0'
+  spec.add_runtime_dependency 'bunny', '>= 2.7.4'
   spec.add_runtime_dependency 'connection_pool', '~> 2.2.2'
   spec.add_runtime_dependency 'sucker_punch', '~> 2.0'
 


### PR DESCRIPTION
'activesupport', '> 5.0.0'
'bunny', '>= 2.7.4'

Fixed typo in readme.