### PR TITLE
Configurable timeout.

### DIFF
--- a/lib/rabbitmq_client.rb
+++ b/lib/rabbitmq_client.rb
@@ -50,11 +50,13 @@ module RabbitmqClient
   # default rabbitmq configs
   # heartbeat_publisher = 0
   # session_pool = 1
+  # session_pool_timeout = 5
   config_accessor(:session_params, instance_accessor: false) do
     {
       heartbeat_publisher: 0,
       async_publisher: true,
-      session_pool: 1
+      session_pool: 1,
+      session_pool_timeout: 5
     }
   end
 

--- a/lib/rabbitmq_client/publisher.rb
+++ b/lib/rabbitmq_client/publisher.rb
@@ -57,7 +57,8 @@ module RabbitmqClient
 
     def create_connection_pool
       pool_size = @session_params.fetch(:session_pool, 1)
-      ConnectionPool.new(size: pool_size) do
+      pool_timeout = @session_params.fetch(:session_pool_timeout, 5)
+      ConnectionPool.new(size: pool_size, timeout: pool_timeout) do
         Bunny.new(@config[:rabbitmq_url],
                   { logger: RabbitmqClient.logger }.merge(@session_params))
       end


### PR DESCRIPTION
Make ConnectionPool timeout configurable via config variable.

Example:
session_params{
  session_pool_timeout: 5
}